### PR TITLE
Fix directory handling in clone_OpenCorePkg

### DIFF
--- a/buildme
+++ b/buildme
@@ -138,17 +138,19 @@ fi
 
 # Clone OR Update OpenCorePkg
 function clone_OpenCorePkg() {
-cd "${CLOVERROOT}"
-if [ ! -d OpenCorePkg/AppleModels ]; then
-  echo "Cloning OpenCorePkg...."
-  git clone https://github.com/CloverHackyColor/OpenCorePkg.git > /dev/null
-  cd "${OpenCorePkg}"
-  git submodule update --init
-else
-  echo "Updating OpenCorePkg...."
-  cd "${OpenCorePkg}"
-  git pull > /dev/null
-fi	
+  pushd . >/dev/null
+  cd "${CLOVERROOT}"
+  if [ ! -d OpenCorePkg/AppleModels ]; then
+    echo "Cloning OpenCorePkg...."
+    git clone https://github.com/CloverHackyColor/OpenCorePkg.git > /dev/null
+    cd "${OpenCorePkg}"
+    git submodule update --init
+  else
+    echo "Updating OpenCorePkg...."
+    cd "${OpenCorePkg}"
+    git pull > /dev/null
+  fi
+  popd >/dev/null
 }
 
 updateClover() {


### PR DESCRIPTION
## Summary
- keep the caller's working directory while cloning OpenCorePkg

## Testing
- `bash -n buildme`


------
https://chatgpt.com/codex/tasks/task_e_684467ffc0bc8328a13e63d3f5f19a53

## Summary by Sourcery

Bug Fixes:
- Ensure clone_OpenCorePkg preserves the calling shell's current directory after cloning.