### PR TITLE
Add shebang and error handling to test scripts

### DIFF
--- a/RedfishPkg/Library/JsonLib/jansson/test/scripts/run-tests.sh
+++ b/RedfishPkg/Library/JsonLib/jansson/test/scripts/run-tests.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+set -e
 # Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
 #
 # Jansson is free software; you can redistribute it and/or modify

--- a/RedfishPkg/Library/JsonLib/jansson/test/suites/api/run
+++ b/RedfishPkg/Library/JsonLib/jansson/test/suites/api/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 #
 # Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
 #

--- a/RedfishPkg/Library/JsonLib/jansson/test/suites/encoding-flags/run
+++ b/RedfishPkg/Library/JsonLib/jansson/test/suites/encoding-flags/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 #
 # Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
 #

--- a/RedfishPkg/Library/JsonLib/jansson/test/suites/invalid-unicode/run
+++ b/RedfishPkg/Library/JsonLib/jansson/test/suites/invalid-unicode/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 #
 # Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
 #

--- a/RedfishPkg/Library/JsonLib/jansson/test/suites/invalid/run
+++ b/RedfishPkg/Library/JsonLib/jansson/test/suites/invalid/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 #
 # Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
 #

--- a/RedfishPkg/Library/JsonLib/jansson/test/suites/valid/run
+++ b/RedfishPkg/Library/JsonLib/jansson/test/suites/valid/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 #
 # Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
 #


### PR DESCRIPTION
## Summary
- add missing shebang and 'set -e' to `run-tests.sh`
- enforce exit on error for all suite `run` scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684469590a0c8328abc9c9bb14e12943

## Summary by Sourcery

Add shebang and exit-on-error enforcement to test scripts to ensure failures abort the testing process

Tests:
- Add missing shebang and enable exit-on-error in run-tests.sh
- Enforce exit-on-error with 'set -e' in all test suite run scripts